### PR TITLE
Run container in detached mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This repository is a customized fork of [mavlink-router](https://github.com/mavl
 that is designed for deployment on VOXL UAVs to redirect its onboard mavsdk to
 a unique port on the ground station.
 
+Ensure the Docker is installed on the VOXL before installing `mavlink-router`.
+
 ## One-Time Setup
 
-**ETC**: ~2 minutes per VOXL
+**ETC**: ~3 minutes per VOXL
 
 ### On Laptop
 
@@ -18,8 +20,8 @@ git clone git@github.com:noda-ai/mavlink-router.git
 
 # (optionally check out specific tag)
 
-# Copy whole directory to VOXL (e.g. 10.8.0.6)
-sshpass -e scp -r ./mavlink-router root@10.8.0.6:/home/root/
+# Copy whole directory to VOXL (e.g. 10.8.0.7)
+sshpass -e scp -r ./mavlink-router root@10.8.0.7:/home/root/
 ```
 
 Repeat the last command for each VOXL you want to deploy.
@@ -32,11 +34,8 @@ SSH into the VOXL, then run the following:
 # Navigate to mavlink-router
 cd ~/mavlink-router
 
-# Update submodules required for Docker build
-git submodule update --init --recursive
-
-# Build and tag image
-docker build . -t noda-mavlink-router
+# Set up mavlink-router and configure auto-start (via cron) with a preset ground station IP (e.g. 10.8.0.2)
+./scripts/setup.sh 10.8.0.2
 ```
 
 ## Run Manually
@@ -45,7 +44,9 @@ SSH into the VOXL, then run the following:
 
 ```sh
 # Start mavlink-router
-# - uses $1 or $GCS_IP for target (ground station) IP address
+# - takes in one argument: ground station IP address
 # - automatically sets port based on MAV_SYS_ID (check with `px4-param show MAV_SYS_ID`)
-./run-mavlink-router.sh <ground_station_ip>
+./scripts/run-mavlink-router.sh 10.8.0.2
 ```
+
+This will stop any running `mavlink-router` container and start a new one.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ git clone git@github.com:noda-ai/mavlink-router.git
 
 # (optionally check out specific tag)
 
-# Copy whole directory to VOXL (e.g. 10.8.0.7)
-sshpass -e scp -r ./mavlink-router root@10.8.0.7:/home/root/
+# Copy whole directory to VOXL (e.g. 10.8.0.6)
+sshpass -e scp -r ./mavlink-router root@10.8.0.6:/home/root/
 ```
 
 Repeat the last command for each VOXL you want to deploy.
@@ -38,31 +38,6 @@ git submodule update --init --recursive
 # Build and tag image
 docker build . -t noda-mavlink-router
 ```
-
-## Run Automatically on Boot
-
-SSH into the VOXL, then run the following:
-
-```sh
-# Set GCS_IP environment variable on every boot
-mkdir -p ~/.profile.d
-echo "export GCS_IP=10.8.0.2" > ~/.profile.d/noda.sh
-chmod +x ~/.profile.d/noda.sh
-```
-
-Then edit the VOXL's crontab:
-
-```sh
-crontab -e
-```
-
-Add the following line:
-
-```sh
-@reboot /home/root/mavlink-router/run-mavlink-router.sh
-```
-
-Now the VOXL should start up the `mavlink-router` container on every boot pointed to the ground station at `10.8.0.2`.
 
 ## Run Manually
 

--- a/run-mavlink-router.sh
+++ b/run-mavlink-router.sh
@@ -58,12 +58,17 @@ echo "Using GCS_IP=$GCS_IP, MAV_SYS_ID=$MAV_SYS_ID, GCS_PORT=$GCS_PORT"
 # Ensure
 echo "Ensure voxl-mavlink-server is running"
 systemctl restart voxl-mavlink-server
+systemctl status voxl-mavlink-server
 
 # Run the container with explicit command
-echo "Running mavlink-routerd with: GCS endpoint $GCS_IP:$GCS_PORT, local endpoint 0.0.0.0:$VOXL_VISION_HUB_PORT"
-docker run --rm -it \
+echo "Starting mavlink-router container using the following configurations:"
+echo ""
+echo "  Ground station: $GCS_IP:$GCS_PORT"
+echo "  Onboard port: $VOXL_VISION_HUB_PORT"
+echo ""
+
+docker run --rm -d \
   --network=host \
-  -e GCS_IP="$GCS_IP" \
-  -e GCS_PORT="$GCS_PORT" \
+  --name=noda-mavlink-router \
   noda-mavlink-router \
   /mavlink-router/build/src/mavlink-routerd -e "$GCS_IP:$GCS_PORT" 0.0.0.0:$VOXL_VISION_HUB_PORT

--- a/scripts/run-mavlink-router.sh
+++ b/scripts/run-mavlink-router.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 # Script to run the mavlink-router Docker container with dynamic GCS_PORT based on MAV_SYS_ID
 
-# Check if command-line argument was provided first
+# Check if ground station IP was provided
 if [ $# -ge 1 ]; then
   GCS_IP="$1"
   echo "Using GCS_IP=$GCS_IP from command-line argument"
-# If not, check if environment variable is set
-elif [ -n "$GCS_IP" ]; then
-  echo "Using GCS_IP=$GCS_IP from environment variable"
-# If neither, show error and exit
 else
   echo "Error: GCS_IP not provided"
   echo "Please provide it as a command-line argument: $0 <ip_address>"
-  echo "Or set it as an environment variable: export GCS_IP=<ip_address>"
   exit 1
 fi
 
-# Default values
+# Stop existing container if running
+if [ -n "$(docker ps -q -f name=noda-mavlink-router)" ]; then
+  docker stop noda-mavlink-router
+fi
+
+# Initial MAVLink port (for MAV_SYS_ID = 1)
 BASE_PORT=14540
 
 # Get MAV_SYS_ID from px4-param
@@ -27,9 +27,9 @@ CONFIG_FILE="/etc/modalai/voxl-vision-hub.conf"
 DEFAULT_PORT=14551
 
 if [ -f "$CONFIG_FILE" ]; then
-  # Use a more specific pattern to find the correct entry
   # Look for the line with "localhost_udp_port_number" that's not commented out
   PORT_LINE=$(grep -v '^[[:space:]]*#' "$CONFIG_FILE" | grep "localhost_udp_port_number" | tail -1)
+  LOCAL_MAVLINK_ENABLED_LINE=$(grep -v '^[[:space:]]*#' "$CONFIG_FILE" | grep "en_localhost_mavlink_udp" | tail -1)
 
   if [ -n "$PORT_LINE" ]; then
     # Extract just the number after the colon and before the comma or end of line
@@ -46,19 +46,38 @@ if [ -f "$CONFIG_FILE" ]; then
     VOXL_VISION_HUB_PORT=$DEFAULT_PORT
     echo "No 'localhost_udp_port_number' entry found in $CONFIG_FILE, using default: $VOXL_VISION_HUB_PORT"
   fi
+
+  # Check if local mavlink is enabled
+  if [ -n "$LOCAL_MAVLINK_ENABLED_LINE" ]; then
+    # Get boolean value
+    LOCAL_MAVLINK_ENABLED=$(echo "$LOCAL_MAVLINK_ENABLED_LINE" | grep -o 'true\|false' | head -1)
+
+    # Validate that we got a boolean
+    if [[ "$LOCAL_MAVLINK_ENABLED" == "true" ]]; then
+      echo "Local mavlink is enabled in $CONFIG_FILE"
+    else
+      # Enable it
+      echo "Enabling local mavlink in $CONFIG_FILE"
+      # Use a flexible sed pattern for JSON format with variable whitespace
+      sed -i 's/"en_localhost_mavlink_udp"[[:space:]]*:[[:space:]]*false/"en_localhost_mavlink_udp": true/g' "$CONFIG_FILE"
+    fi
+  fi
 else
   VOXL_VISION_HUB_PORT=$DEFAULT_PORT
   echo "Config file $CONFIG_FILE not found, using default port: $VOXL_VISION_HUB_PORT"
 fi
 
 # Calculate GCS_PORT
-GCS_PORT=$((BASE_PORT + MAV_SYS_ID))
+GCS_PORT=$((BASE_PORT + MAV_SYS_ID - 1))
 echo "Using GCS_IP=$GCS_IP, MAV_SYS_ID=$MAV_SYS_ID, GCS_PORT=$GCS_PORT"
 
-# Ensure
+# Ensure VOXL services are running
 echo "Ensure voxl-mavlink-server is running"
 systemctl restart voxl-mavlink-server
-systemctl status voxl-mavlink-server
+systemctl status --no-pager voxl-mavlink-server
+
+systemctl restart voxl-vision-hub
+systemctl status --no-pager voxl-vision-hub
 
 # Run the container with explicit command
 echo "Starting mavlink-router container using the following configurations:"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Submodule update required for Docker build
+git submodule update --init --recursive
+
+# Build and tag Docker image
+docker build . -t noda-mavlink-router
+
+# Check if arg $1 provided
+if [ -z "$1" ]; then
+  echo "Error: GCS IP not provided"
+  echo "Please provide it as a command-line argument: $0 <ip_address>"
+  exit 1
+fi
+
+echo "Setting up mavlink-router to start at boot with GCS IP $1..."
+
+# Get the git project root directory
+PROJECT_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+( crontab -l | grep -v -F "mavlink-router" ; echo "@reboot $PROJECT_ROOT/scripts/run-mavlink-router.sh $1" ) | crontab -
+
+echo "Successfully configured cron job!"


### PR DESCRIPTION
# Improved MAVLink Router Setup and Configuration

This PR enhances the MAVLink router deployment process with:

1. Added a new `scripts/setup.sh` for one-time configuration that:
   - Updates git submodules
   - Builds the Docker image
   - Sets up the cron job with the provided ground station IP

2. Restructured the run script (`run-mavlink-router.sh` → `scripts/run-mavlink-router.sh`) to:
   - Stop any existing container before starting a new one
   - Run the container in detached mode with a consistent name
   - Calculate GCS port based on MAV_SYS_ID (now properly zero-indexed)
   - Check and enable local MAVLink in the VOXL configuration if needed
   - Restart and verify both voxl-mavlink-server and voxl-vision-hub services
   - Provide clearer logging of configuration parameters

3. Simplified the README with:
   - Docker prerequisite note
   - Updated ETC time estimate
   - Streamlined installation instructions using the new setup script
   - Clearer manual run instructions