### PR TITLE
Wait for docker and px4 services before starting mavlink-router

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,6 +17,6 @@ echo "Setting up mavlink-router to start at boot with GCS IP $1..."
 
 # Get the git project root directory
 PROJECT_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
-( crontab -l | grep -v -F "mavlink-router" ; echo "@reboot $PROJECT_ROOT/scripts/run-mavlink-router.sh $1" ) | crontab -
+( crontab -l | grep -v -F "mavlink-router" ; echo "@reboot $PROJECT_ROOT/scripts/run-mavlink-router.sh $1 >> /tmp/cron_mavlink_router.log 2>&1" ) | crontab -
 
 echo "Successfully configured cron job!"


### PR DESCRIPTION
## Summary

Improved MAVLink router startup reliability with Docker and PX4 parameter service dependency handling.

### Changes

- Added Docker daemon availability check with a retry mechanism before starting the MAVLink router
- Implemented a more robust method to retrieve MAV_SYS_ID from px4-param with retries
- Added logging for the MAVLink router cron job by redirecting output to `/tmp/cron_mavlink_router.log`

### How to test?

[Screen Recording 2025-04-11 at 10.19.02 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/FWbTJ2xAZHpw9GKDDQ8V/4900439a-5933-418b-8dde-05d4a90e7e96.mov" />](https://app.graphite.dev/media/video/FWbTJ2xAZHpw9GKDDQ8V/4900439a-5933-418b-8dde-05d4a90e7e96.mov)

1. Run the setup script with a GCS IP: `./scripts/setup.sh <GCS_IP>`
2. Reboot the system and verify the MAVLink router starts properly
3. Check `/tmp/cron_mavlink_router.log` for any startup issues
4. Verify the router connects successfully even when Docker or px4-param services take time to initialize

### Why make this change?

The MAVLink router was failing to start properly during system boot when Docker wasn't fully initialized or when the px4-param service wasn't ready to provide the MAV_SYS_ID. These changes make the startup process more resilient by adding appropriate wait mechanisms and better error handling, ensuring reliable MAVLink communication after system boot.